### PR TITLE
Remove replication execution update and delete permission

### DIFF
--- a/src/common/rbac/const.go
+++ b/src/common/rbac/const.go
@@ -102,9 +102,7 @@ var (
 
 			{Resource: ResourceReplication, Action: ActionRead},
 			{Resource: ResourceReplication, Action: ActionCreate},
-			{Resource: ResourceReplication, Action: ActionDelete},
 			{Resource: ResourceReplication, Action: ActionList},
-			{Resource: ResourceReplication, Action: ActionUpdate},
 
 			{Resource: ResourceReplicationAdapter, Action: ActionList},
 


### PR DESCRIPTION
Remove replication execution update and delete permission, Because Harbor doesn't have the permission.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
